### PR TITLE
[CI-0] Fix self-healing PR detection logic

### DIFF
--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -41,54 +41,30 @@ jobs:
             console.log(`Commit: ${headSha}`);
             console.log(`Associated PRs: ${pullRequests.length}`);
 
+            // Prefer the PR head ref over head_branch, since head_branch
+            // can resolve to "main" for PR-triggered CI runs.
             let branch = headBranch;
             let prNumber = '';
-            let hasPr = false;
 
             if (pullRequests.length > 0) {
-              // Find PR matching the head SHA
-              const matchingPrs = pullRequests.filter(pr => pr.head.sha === headSha);
-
-              if (matchingPrs.length > 0) {
-                const pr = matchingPrs[0];
-                if (matchingPrs.length > 1) {
-                  console.log(`Warning: Multiple PRs match head SHA. Using first one: #${pr.number}`);
-                }
-                branch = pr.head.ref;
-                prNumber = String(pr.number);
-                hasPr = true;
-                console.log(`PR #${prNumber} detected matching head SHA, using head ref: ${branch}`);
-              } else {
-                console.log('No associated PRs match the head SHA.');
-              }
+              const pr = pullRequests[0];
+              branch = pr.head.ref;
+              prNumber = String(pr.number);
+              console.log(`PR #${prNumber} detected, using head ref: ${branch}`);
             } else {
-              console.log('No associated PRs found.');
-            }
-
-            if (!hasPr) {
-                console.log('Skipping self-healing as no valid PR was found.');
+              console.log(`No associated PRs — using head_branch: ${branch}`);
             }
 
             core.setOutput('branch', branch);
             core.setOutput('sha', headSha);
             core.setOutput('run_id', runId);
             core.setOutput('pr_number', prNumber);
-            core.setOutput('has_pr', hasPr);
 
       - name: Check self-healing attempts
         id: check-attempts
         uses: actions/github-script@v7
         with:
           script: |
-            const hasPr = '${{ steps.get-branch.outputs.has_pr }}' === 'true';
-
-            if (!hasPr) {
-              console.log('No PR found. Skipping self-healing.');
-              core.setOutput('should_attempt', false);
-              core.setOutput('attempt_count', 0);
-              return;
-            }
-
             const branch = '${{ steps.get-branch.outputs.branch }}';
             const maxAttempts = 3;
 
@@ -360,14 +336,36 @@ jobs:
           PR_NUMBER: ${{ needs.analyze-failure.outputs.pr_number }}
         with:
           script: |
+            const branch = '${{ needs.analyze-failure.outputs.branch }}';
             const success = process.env.JULES_SUCCESS === 'true';
             const sessionId = process.env.SESSION_ID;
             const error = process.env.JULES_ERROR;
             const attempt = parseInt(process.env.ATTEMPT) + 1;
-            const prNumber = parseInt(process.env.PR_NUMBER);
+            const prNumberFromRun = process.env.PR_NUMBER;
+
+            // Use PR number from workflow_run.pull_requests if available,
+            // otherwise fall back to searching by branch name.
+            let prNumber = null;
+
+            if (prNumberFromRun) {
+              prNumber = parseInt(prNumberFromRun, 10);
+              console.log(`Using PR #${prNumber} from workflow_run.pull_requests`);
+            } else {
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${branch}`,
+                state: 'open'
+              });
+
+              if (prs.length > 0) {
+                prNumber = prs[0].number;
+                console.log(`Found PR #${prNumber} by branch search`);
+              }
+            }
 
             if (!prNumber) {
-              console.log('No PR number available — skipping comment');
+              console.log('No open PR found — skipping comment');
               return;
             }
 
@@ -427,23 +425,29 @@ jobs:
     steps:
       - name: Create escalation issue
         uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ needs.analyze-failure.outputs.pr_number }}
         with:
           script: |
             const branch = '${{ needs.analyze-failure.outputs.branch }}';
             const attemptCount = '${{ needs.analyze-failure.outputs.attempt_count }}';
-            const prNumber = process.env.PR_NUMBER ? parseInt(process.env.PR_NUMBER) : null;
+            const prNumberFromRun = '${{ needs.analyze-failure.outputs.pr_number }}';
 
-            // Only proceed if attempts were made but failed to fix,
-            // OR if we are escalating for other reasons (but here we are triggered if should_attempt_fix is false).
-            // This job runs when should_attempt_fix == 'false'.
-            // This happens if maxAttempts reached OR if no PR found.
-            // We only want to escalate if maxAttempts reached.
+            // Find the related PR: prefer workflow_run data, fall back to branch search
+            let relatedPr = null;
 
-            if (parseInt(attemptCount) < 3) {
-              console.log('Attempts < 3, likely skipped due to no PR. No escalation needed.');
-              return;
+            if (prNumberFromRun) {
+              relatedPr = { number: parseInt(prNumberFromRun, 10) };
+              console.log(`Using PR #${relatedPr.number} from workflow_run.pull_requests`);
+            } else {
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${branch}`,
+                state: 'open'
+              });
+              if (prs.length > 0) {
+                relatedPr = prs[0];
+                console.log(`Found PR #${relatedPr.number} by branch search`);
+              }
             }
 
             const issueBody = [
@@ -464,7 +468,7 @@ jobs:
               '3. Apply manual fixes',
               '4. Push changes to trigger CI',
               '',
-              prNumber ? `### Related PR\n- #${prNumber}` : '',
+              relatedPr ? `### Related PR\n- #${relatedPr.number}` : '',
               '',
               '---',
               '*Created by self-healing pipeline*'
@@ -480,7 +484,7 @@ jobs:
 
             console.log(`Created escalation issue #${issue.number}`);
 
-            if (prNumber) {
+            if (relatedPr) {
               const commentBody = [
                 '## 🚨 Jules Self-Healing Exhausted',
                 '',
@@ -494,7 +498,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: prNumber,
+                issue_number: relatedPr.number,
                 body: commentBody
               });
             }


### PR DESCRIPTION
## Summary

- Use `workflow_run.pull_requests[0]` to get PR head ref and number instead of relying on `head_branch` which resolves to `"main"` for PR-triggered CI runs
- Add fallback branch-based PR lookup for comment and escalation steps when `pull_requests` array is empty
- Remove brittle `has_pr` gate that silently skipped self-healing
- Pass `pr_number` as a job output for direct PR commenting

### Problem

The self-healing pipeline's `get-branch` step filtered `workflow_run.pull_requests` by matching `head.sha`, but `head_branch` would resolve to `"main"` for PR-triggered CI runs. This caused Jules to target the wrong branch and prevented status comments from being posted to the correct PR.

The `has_pr` guard also silently aborted the entire self-healing flow if no PR matched the SHA filter, even when a valid PR existed.

### Fix

1. Use `pullRequests[0].head.ref` directly (simpler, correct for the common case)
2. Fall back to `pulls.list` by branch name when `workflow_run.pull_requests` is empty
3. Remove `has_pr` output — the flow now proceeds with branch-only context when no PR is found

### Jira Ticket

Infrastructure improvement — no Jira ticket.

### Type of Change
- [x] Bugfix (fixes an issue)

### Testing

- [x] Verified PR detection logic matches GitHub Actions `workflow_run` event schema
- [x] Confirmed fallback branch search uses correct `head` filter format

### Checklist
- [x] PR title contains Jira ID: `[CI-0]`
- [x] Branch follows naming convention: `claude/CI-0-fix-jules`
- [x] Code has been self-reviewed

Supersedes #18.